### PR TITLE
Update environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -9,6 +9,6 @@ dependencies:
   - pandas=0.20.3
   - pytables=3.4.2
   - toolz=0.8.2
-  - numpy=1.14.5
+  - numpy=1.15.4
   - ipyparallel
   - dill


### PR DESCRIPTION
Kwant can't be loaded if numpy==1.14.5
Pandas doesn't work well if NumPy is up to date.
Change NumPy version to 1.15.4